### PR TITLE
Bump steam dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,1509 @@
 {
     "name": "steam-auto-confirmation",
     "version": "0.0.2",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
-    "dependencies": {
-        "@doctormckay/proxy-agent": {
+    "packages": {
+        "": {
+            "name": "steam-auto-confirmation",
+            "version": "0.0.2",
+            "license": "GNU",
+            "dependencies": {
+                "merge": "^1.2.0",
+                "steam-client": "^2.5.8",
+                "steam-totp": "^2.1.1",
+                "steam-tradeoffer-manager": "^2.10.3",
+                "steam-user": "^4.19.12",
+                "steamcommunity": "^3.43.1",
+                "tracer": "^0.9.1"
+            },
+            "engines": {
+                "node": ">=8.11.0"
+            }
+        },
+        "node_modules/@bbob/parser": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.7.0.tgz",
+            "integrity": "sha512-lTs7rcz6BmS8PI98jQJrr/iq+BeZIuXAmQNAgSQJxTxalD1wln90g5Vf/keYppONg+cw9JKE8klFYVUhgd2C4Q==",
+            "dependencies": {
+                "@bbob/plugin-helper": "^2.7.0"
+            }
+        },
+        "node_modules/@bbob/plugin-helper": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.7.0.tgz",
+            "integrity": "sha512-t5Uj2JxTOQ1Lmsx2RoXpNTsavQDz3sknsQfspsSSuDeWl9Ue+p0afQJ81El6NfsNKb45X5lNjZ9hxZIQJnin1g=="
+        },
+        "node_modules/@doctormckay/stats-reporter": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@doctormckay/stats-reporter/-/stats-reporter-1.0.4.tgz",
+            "integrity": "sha512-J8YqHQGZ3OdrT4xzWOzvA/p3vnXNnSOsAybPa5+02YE5U46JbZexfzU8nJV+2iN7GWhGvLAQNgdvFHl5WKB4iw==",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/@doctormckay/stdlib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.14.1.tgz",
+            "integrity": "sha512-jGuJydIo2JB6IgOkOPNRr6fTJH9IdJCGH9yfVoEWzBjH0ptn22KsvOuJW+BG96O1eI1jSQ5C5myZr5Rj4gZ+Qw==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@doctormckay/steam-crypto": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
+            "integrity": "sha1-KxI8HpgDTzyMa5AQnjX8QnbghrA="
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "node_modules/@types/long": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+        },
+        "node_modules/@types/node": {
+            "version": "16.9.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+            "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
+        },
+        "node_modules/adm-zip": {
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+            "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+            "engines": {
+                "node": ">=0.3.0"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dependencies": {
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/appdirectory": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/appdirectory/-/appdirectory-0.1.0.tgz",
+            "integrity": "sha1-62yBYyDnsqsW9e2ZfyjYIF31Y3U="
+        },
+        "node_modules/ascli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
+            "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
+            "dependencies": {
+                "colour": "~0.7.1",
+                "optjs": "~3.2.2"
+            }
+        },
+        "node_modules/asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dependencies": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "node_modules/assert-plus": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@doctormckay/proxy-agent/-/proxy-agent-1.0.0.tgz",
-            "integrity": "sha512-hRTwpPYRBjEEiOz1FMOPL8NNo73sczXVIibGV+M9b56qL7uSu87gwIRqgjfc0Ebmli0qbltohtWfDy4ZStZosg=="
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/async": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "dependencies": {
+                "lodash": "^4.17.14"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "node_modules/aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "node_modules/bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "optional": true,
+            "dependencies": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "node_modules/binarykvparser": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binarykvparser/-/binarykvparser-2.2.0.tgz",
+            "integrity": "sha512-mGBKngQF9ui53THcMjgjd0LrBH/HsI2Vywfjq52udSAmRGG87h0vjhkqun0kF+iC4rQ2jLZqldwJE7YN2ueiWw==",
+            "bundleDependencies": [
+                "long"
+            ],
+            "dependencies": {
+                "long": "^3.2.0"
+            }
+        },
+        "node_modules/binarykvparser/node_modules/long": {
+            "version": "3.2.0",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/bytebuffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
+            "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
+            "dependencies": {
+                "long": "~3"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "node_modules/cheerio": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+            "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+            "dependencies": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash.assignin": "^4.0.9",
+                "lodash.bind": "^4.1.4",
+                "lodash.defaults": "^4.0.1",
+                "lodash.filter": "^4.4.0",
+                "lodash.flatten": "^4.2.0",
+                "lodash.foreach": "^4.3.0",
+                "lodash.map": "^4.4.0",
+                "lodash.merge": "^4.4.0",
+                "lodash.pick": "^4.2.1",
+                "lodash.reduce": "^4.4.0",
+                "lodash.reject": "^4.4.0",
+                "lodash.some": "^4.4.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "node_modules/co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "engines": {
+                "iojs": ">= 1.0.0",
+                "node": ">= 0.12.0"
+            }
+        },
+        "node_modules/code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/colors": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
+            "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ==",
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/colour": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
+            "integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g=",
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "node_modules/core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "node_modules/css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dependencies": {
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
+                "domutils": "1.5.1",
+                "nth-check": "~1.0.1"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+            "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/cuint": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+            "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+        },
+        "node_modules/dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/deep-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+            "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dependencies": {
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/domelementtype": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+            "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        },
+        "node_modules/domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "deprecated": "update to domelementtype@1.3.1"
+        },
+        "node_modules/domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dependencies": {
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dependencies": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "node_modules/ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "optional": true,
+            "dependencies": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "node_modules/extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "engines": [
+                "node >=0.6.0"
+            ]
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "node_modules/fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "node_modules/file-manager": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-1.0.1.tgz",
+            "integrity": "sha1-yZySdeSoyNr13vFR9rUUBVIegXo=",
+            "dependencies": {
+                "async": "^1.4.2"
+            }
+        },
+        "node_modules/file-manager/node_modules/async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "node_modules/forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 0.12"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "node_modules/getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dependencies": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "node_modules/glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/har-validator": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+            "deprecated": "this library is no longer supported",
+            "dependencies": {
+                "ajv": "^5.3.0",
+                "har-schema": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "dependencies": {
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "node_modules/http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            },
+            "engines": {
+                "node": ">=0.8",
+                "npm": ">=1.3.7"
+            }
+        },
+        "node_modules/image-size": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.8.3.tgz",
+            "integrity": "sha512-SMtq1AJ+aqHB45c3FsB4ERK0UCiA2d3H1uq8s+8T0Pf8A3W4teyBQyaFaktH6xvZqh+npwlKU7i4fJo0r7TYTg==",
+            "dependencies": {
+                "queue": "6.0.1"
+            },
+            "bin": {
+                "image-size": "bin/image-size.js"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "node_modules/invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "node_modules/isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "node_modules/jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "optional": true
+        },
+        "node_modules/json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "node_modules/jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "node_modules/languages": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/languages/-/languages-0.1.3.tgz",
+            "integrity": "sha1-8ZJzuw6Uas0t6xDAfHUO4Si91LA="
+        },
+        "node_modules/lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dependencies": {
+                "invert-kv": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "node_modules/lodash.assignin": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+            "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+        },
+        "node_modules/lodash.bind": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+            "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+        },
+        "node_modules/lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+        },
+        "node_modules/lodash.filter": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+            "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+        },
+        "node_modules/lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+        },
+        "node_modules/lodash.foreach": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+            "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+        },
+        "node_modules/lodash.map": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+            "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+        },
+        "node_modules/lodash.pick": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+        },
+        "node_modules/lodash.reduce": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+            "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+        },
+        "node_modules/lodash.reject": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+            "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+        },
+        "node_modules/lodash.some": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+            "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
+        },
+        "node_modules/long": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+            "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/lzma": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
+            "integrity": "sha1-N4OySFi5wOdHoN88vx+1/KqSxEE=",
+            "bin": {
+                "lzma.js": "bin/lzma.js"
+            }
+        },
+        "node_modules/merge": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+            "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+        },
+        "node_modules/mime-db": {
+            "version": "1.36.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+            "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.20",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+            "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+            "dependencies": {
+                "mime-db": "~1.36.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "0.0.8",
+            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+            "dependencies": {
+                "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/node-bignumber": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/node-bignumber/-/node-bignumber-1.2.1.tgz",
+            "integrity": "sha1-JmyVUzUoOFOfZhyS5YYxvpeRfqU=",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/nth-check": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+            "dependencies": {
+                "boolbase": "~1.0.0"
+            }
+        },
+        "node_modules/number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/optjs": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
+            "integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
+        },
+        "node_modules/os-locale": {
+            "version": "1.4.0",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dependencies": {
+                "lcid": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "node_modules/permessage-deflate": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/permessage-deflate/-/permessage-deflate-0.1.6.tgz",
+            "integrity": "sha1-WB8c7fvUQPrEfQd3vohjM4a5kt4=",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "node_modules/protobufjs": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+            "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+            "dependencies": {
+                "ascli": "~1",
+                "bytebuffer": "~5",
+                "glob": "^7.0.5",
+                "yargs": "^3.10.0"
+            },
+            "bin": {
+                "pbjs": "bin/pbjs"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+        },
+        "node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "node_modules/qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/queue": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.1.tgz",
+            "integrity": "sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==",
+            "dependencies": {
+                "inherits": "~2.0.3"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+            "dependencies": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "node_modules/sax": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "node_modules/sshpk": {
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+            "dependencies": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "getpass": "^0.1.1",
+                "safer-buffer": "^2.0.2"
+            },
+            "bin": {
+                "sshpk-conv": "bin/sshpk-conv",
+                "sshpk-sign": "bin/sshpk-sign",
+                "sshpk-verify": "bin/sshpk-verify"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "optionalDependencies": {
+                "bcrypt-pbkdf": "^1.0.0",
+                "ecc-jsbn": "~0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "node_modules/steam-appticket": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.1.tgz",
+            "integrity": "sha512-oYVInCvJlPPaQPYW1+iGcVP0N0ZvwtWiCDM1Z353XJ8l4DXQI/N+R5yyaRQcHRH5oQv3+BY6gPF40lu7gwEiJw==",
+            "dependencies": {
+                "@doctormckay/stdlib": "^1.6.0",
+                "@doctormckay/steam-crypto": "^1.2.0",
+                "bytebuffer": "^5.0.1",
+                "protobufjs": "^6.8.8",
+                "steamid": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/steam-appticket/node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "node_modules/steam-appticket/node_modules/protobufjs": {
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": ">=13.7.0",
+                "long": "^4.0.0"
+            },
+            "bin": {
+                "pbjs": "bin/pbjs",
+                "pbts": "bin/pbts"
+            }
+        },
+        "node_modules/steam-client": {
+            "version": "2.5.8",
+            "resolved": "https://registry.npmjs.org/steam-client/-/steam-client-2.5.8.tgz",
+            "integrity": "sha512-pzD4Ns5JwI1gb2FjdaUOoRp1aO6CkcArPTRAd+B1lxiItVvxBeDoPpw81OorO2mnVlwq1awyvAdSlm9ov9+Z4Q==",
+            "dependencies": {
+                "@doctormckay/steam-crypto": "^1.2.0",
+                "async": "^2.5.0",
+                "buffer-crc32": "^0.2.13",
+                "bytebuffer": "^5.0.0",
+                "protobufjs": "^5.0.2",
+                "websocket13": "^1.7.4"
+            },
+            "engines": {
+                "node": ">=4.1.1"
+            }
+        },
+        "node_modules/steam-totp": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.1.tgz",
+            "integrity": "sha512-d+tjnr3wwDkbrKFxjYZ0uK4CSF09oJwCmlGH8SdOlTDkbtBPuNhPKY0XzZxQVltZF6/JkEYj+uz+kBr6UrY7BQ==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/steam-tradeoffer-manager": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/steam-tradeoffer-manager/-/steam-tradeoffer-manager-2.10.3.tgz",
+            "integrity": "sha512-/e8yc4iORfHFDPF/tR8Oh2vdbZ+vR4puFEVc2fgQTLIBBJK2rnRsu3np2M4knd/T47DihJt54gUTn++ttjCOnA==",
+            "dependencies": {
+                "@doctormckay/stdlib": "^1.5.1",
+                "appdirectory": "^0.1.0",
+                "async": "^2.6.0",
+                "deep-equal": "^1.0.1",
+                "file-manager": "^1.0.1",
+                "languages": "^0.1.3",
+                "steamcommunity": "^3.33.1",
+                "steamid": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/steam-user": {
+            "version": "4.19.12",
+            "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.19.12.tgz",
+            "integrity": "sha512-7q9mDGc3YX5SI9QnXFqN52w+H8wCY1yB06sz2zweeLPWraq4VVYtymsjXybhu1mym7cKE23RFkFQSQclRK0fyw==",
+            "dependencies": {
+                "@bbob/parser": "^2.2.0",
+                "@doctormckay/stdlib": "^1.11.1",
+                "@doctormckay/steam-crypto": "^1.2.0",
+                "adm-zip": "^0.4.13",
+                "appdirectory": "^0.1.0",
+                "binarykvparser": "^2.2.0",
+                "bytebuffer": "^5.0.0",
+                "file-manager": "^2.0.0",
+                "lzma": "^2.3.2",
+                "protobufjs": "^6.8.8",
+                "steam-appticket": "^1.0.1",
+                "steam-totp": "^2.0.1",
+                "steamid": "^1.1.0",
+                "vdf": "^0.0.2",
+                "websocket13": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/steam-user/node_modules/file-manager": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.0.tgz",
+            "integrity": "sha512-AX9jtqrrHK9JT4v3J7uMZGkDNiuuG4y4T6LoNm3lKzT/vReLCY8mnRWIpaG2ffNEpJHSkiwKejpu8x8THEYPzg==",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/steam-user/node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "node_modules/steam-user/node_modules/protobufjs": {
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": ">=13.7.0",
+                "long": "^4.0.0"
+            },
+            "bin": {
+                "pbjs": "bin/pbjs",
+                "pbts": "bin/pbts"
+            }
+        },
+        "node_modules/steam-user/node_modules/websocket13": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.2.0.tgz",
+            "integrity": "sha512-m3aS0sLEM9dRM2+Cvgakdr/oLqyfAObdUlUqU3gdw3PuI81k1Hw3PWdwJsehvRRlScHolA13yYsx/X3OUzsTLA==",
+            "dependencies": {
+                "@doctormckay/stdlib": "^1.8.0",
+                "bytebuffer": "^5.0.1",
+                "permessage-deflate": "^0.1.6",
+                "websocket-extensions": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/steamcommunity": {
+            "version": "3.43.1",
+            "resolved": "https://registry.npmjs.org/steamcommunity/-/steamcommunity-3.43.1.tgz",
+            "integrity": "sha512-Nx+Iwas1EWpSIwEEfGw5jLm6Jrl0W/VL+0Ms9gRLnfqH8Ca1PEba7mDhar/Ny4RUdSmgrfy1ZBV99csjkZ5bog==",
+            "dependencies": {
+                "async": "^2.6.3",
+                "cheerio": "0.22.0",
+                "image-size": "^0.8.2",
+                "node-bignumber": "^1.2.1",
+                "request": "^2.88.0",
+                "steam-totp": "^1.5.0",
+                "steamid": "^1.1.3",
+                "xml2js": "^0.4.22"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/steamcommunity/node_modules/steam-totp": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-1.5.0.tgz",
+            "integrity": "sha512-RMlBK5dFtgplDMYYGg/k80RqEntzBcl7C/0RF18fQh9+XPe/iEMsfKmIE+xj8I3hqJW1akANAC6gf+YpfZq52w==",
+            "dependencies": {
+                "@doctormckay/stats-reporter": "^1.0.0"
+            }
+        },
+        "node_modules/steamid": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.3.tgz",
+            "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
+            "dependencies": {
+                "cuint": "^0.2.1"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/tinytim": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
+            "integrity": "sha1-yWih5VWa2VUyJO92J7qzTjyu+Kg=",
+            "engines": {
+                "node": ">= 0.2.0"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "dependencies": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "engines": {
+                "node": ">=0.8"
+            }
+        },
+        "node_modules/tracer": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.9.1.tgz",
+            "integrity": "sha512-8CNhMlajAqbP4hUDWgd5j540tSO7QlP7XLFg7bkPf37yWqfx7uYE/dwTIb+3PLnt+8XIZIQKbU5va7tk45MKXw==",
+            "dependencies": {
+                "colors": "1.2.3",
+                "dateformat": "3.0.3",
+                "mkdirp": "^0.5.1",
+                "tinytim": "0.1.1"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "optional": true
+        },
+        "node_modules/util": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+            "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
+            "dependencies": {
+                "inherits": "2.0.3"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/vdf": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/vdf/-/vdf-0.0.2.tgz",
+            "integrity": "sha1-ve6nvN3sf6/IzcWMMq6ExyXCfhQ=",
+            "dependencies": {
+                "util": "*"
+            }
+        },
+        "node_modules/verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "engines": [
+                "node >=0.6.0"
+            ],
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "node_modules/websocket-extensions": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/websocket13": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-1.7.4.tgz",
+            "integrity": "sha512-nSf/lVmrQDvZay38YEqjRjKAcUY2iAD3mcuM8zmO2fbG6VBRNen/YTQR48bjeOzpt2I30U2AeQeb2RldxmPXKw==",
+            "dependencies": {
+                "bytebuffer": "^5.0.1",
+                "permessage-deflate": "^0.1.6",
+                "websocket-extensions": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/window-size": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+            "bin": {
+                "window-size": "cli.js"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dependencies": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "node_modules/yargs": {
+            "version": "3.32.0",
+            "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "dependencies": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@bbob/parser": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@bbob/parser/-/parser-2.7.0.tgz",
+            "integrity": "sha512-lTs7rcz6BmS8PI98jQJrr/iq+BeZIuXAmQNAgSQJxTxalD1wln90g5Vf/keYppONg+cw9JKE8klFYVUhgd2C4Q==",
+            "requires": {
+                "@bbob/plugin-helper": "^2.7.0"
+            }
+        },
+        "@bbob/plugin-helper": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@bbob/plugin-helper/-/plugin-helper-2.7.0.tgz",
+            "integrity": "sha512-t5Uj2JxTOQ1Lmsx2RoXpNTsavQDz3sknsQfspsSSuDeWl9Ue+p0afQJ81El6NfsNKb45X5lNjZ9hxZIQJnin1g=="
         },
         "@doctormckay/stats-reporter": {
             "version": "1.0.4",
@@ -15,19 +1511,83 @@
             "integrity": "sha512-J8YqHQGZ3OdrT4xzWOzvA/p3vnXNnSOsAybPa5+02YE5U46JbZexfzU8nJV+2iN7GWhGvLAQNgdvFHl5WKB4iw=="
         },
         "@doctormckay/stdlib": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.5.1.tgz",
-            "integrity": "sha512-GwV2eHxqtUHt8kLnc3rCz5fZJnQ5lTOPIN5LrmPQxgTLGG2vsIVRC8qeP3GEC7Msxv5nX99vtL6VpJ8883NCRQ=="
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@doctormckay/stdlib/-/stdlib-1.14.1.tgz",
+            "integrity": "sha512-jGuJydIo2JB6IgOkOPNRr6fTJH9IdJCGH9yfVoEWzBjH0ptn22KsvOuJW+BG96O1eI1jSQ5C5myZr5Rj4gZ+Qw=="
         },
         "@doctormckay/steam-crypto": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@doctormckay/steam-crypto/-/steam-crypto-1.2.0.tgz",
             "integrity": "sha1-KxI8HpgDTzyMa5AQnjX8QnbghrA="
         },
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@types/long": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+        },
+        "@types/node": {
+            "version": "16.9.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.4.tgz",
+            "integrity": "sha512-KDazLNYAGIuJugdbULwFZULF9qQ13yNWEBFnfVpqlpgAAo6H/qnM9RjBgh0A0kmHf3XxAKLdN5mTIng9iUvVLA=="
+        },
         "adm-zip": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
-            "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+            "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
         },
         "ajv": {
             "version": "5.5.2",
@@ -73,11 +1633,11 @@
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "^4.17.14"
             }
         },
         "asynckit": {
@@ -446,6 +2006,14 @@
                 "sshpk": "^1.7.0"
             }
         },
+        "image-size": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.8.3.tgz",
+            "integrity": "sha512-SMtq1AJ+aqHB45c3FsB4ERK0UCiA2d3H1uq8s+8T0Pf8A3W4teyBQyaFaktH6xvZqh+npwlKU7i4fJo0r7TYTg==",
+            "requires": {
+                "queue": "6.0.1"
+            }
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -534,9 +2102,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.assignin": {
             "version": "4.2.0",
@@ -737,6 +2305,14 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
+        "queue": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.1.tgz",
+            "integrity": "sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==",
+            "requires": {
+                "inherits": "~2.0.3"
+            }
+        },
         "readable-stream": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -809,6 +2385,45 @@
                 "tweetnacl": "~0.14.0"
             }
         },
+        "steam-appticket": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/steam-appticket/-/steam-appticket-1.0.1.tgz",
+            "integrity": "sha512-oYVInCvJlPPaQPYW1+iGcVP0N0ZvwtWiCDM1Z353XJ8l4DXQI/N+R5yyaRQcHRH5oQv3+BY6gPF40lu7gwEiJw==",
+            "requires": {
+                "@doctormckay/stdlib": "^1.6.0",
+                "@doctormckay/steam-crypto": "^1.2.0",
+                "bytebuffer": "^5.0.1",
+                "protobufjs": "^6.8.8",
+                "steamid": "^1.1.0"
+            },
+            "dependencies": {
+                "long": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+                    "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+                },
+                "protobufjs": {
+                    "version": "6.11.2",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+                    "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+                    "requires": {
+                        "@protobufjs/aspromise": "^1.1.2",
+                        "@protobufjs/base64": "^1.1.2",
+                        "@protobufjs/codegen": "^2.0.4",
+                        "@protobufjs/eventemitter": "^1.1.0",
+                        "@protobufjs/fetch": "^1.1.0",
+                        "@protobufjs/float": "^1.0.2",
+                        "@protobufjs/inquire": "^1.1.0",
+                        "@protobufjs/path": "^1.1.2",
+                        "@protobufjs/pool": "^1.1.0",
+                        "@protobufjs/utf8": "^1.1.0",
+                        "@types/long": "^4.0.1",
+                        "@types/node": ">=13.7.0",
+                        "long": "^4.0.0"
+                    }
+                }
+            }
+        },
         "steam-client": {
             "version": "2.5.8",
             "resolved": "https://registry.npmjs.org/steam-client/-/steam-client-2.5.8.tgz",
@@ -823,19 +2438,15 @@
             }
         },
         "steam-totp": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.0.tgz",
-            "integrity": "sha512-T7hr05z9jJHIrzkglzoVM+SBeKKVFZo4qBt+0PrwDN8kXypNnnjL6GhMyTg13Z8E9ebvtzn2Tq/z8xF7XlN/Ig==",
-            "requires": {
-                "@doctormckay/stats-reporter": "^1.0.0"
-            }
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-2.1.1.tgz",
+            "integrity": "sha512-d+tjnr3wwDkbrKFxjYZ0uK4CSF09oJwCmlGH8SdOlTDkbtBPuNhPKY0XzZxQVltZF6/JkEYj+uz+kBr6UrY7BQ=="
         },
         "steam-tradeoffer-manager": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/steam-tradeoffer-manager/-/steam-tradeoffer-manager-2.9.4.tgz",
-            "integrity": "sha512-DdWSXviCe8D21uXGVnOMDP7SpON3cumpNUL41WK9NUWzsN4nh6B4q99WRKZl4d/W88gu6HWb0uRMNSfFRqYJ+w==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/steam-tradeoffer-manager/-/steam-tradeoffer-manager-2.10.3.tgz",
+            "integrity": "sha512-/e8yc4iORfHFDPF/tR8Oh2vdbZ+vR4puFEVc2fgQTLIBBJK2rnRsu3np2M4knd/T47DihJt54gUTn++ttjCOnA==",
             "requires": {
-                "@doctormckay/stats-reporter": "^1.0.3",
                 "@doctormckay/stdlib": "^1.5.1",
                 "appdirectory": "^0.1.0",
                 "async": "^2.6.0",
@@ -847,51 +2458,83 @@
             }
         },
         "steam-user": {
-            "version": "3.28.2",
-            "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-3.28.2.tgz",
-            "integrity": "sha512-yDRjlF8hHqsQLqKQs1uvrzFaNmEtGaSa0VWoHMtg9xEnvpGpuedON9G3ClJbIoMreyiKDhRHI0/8coDlJWO+Qw==",
+            "version": "4.19.12",
+            "resolved": "https://registry.npmjs.org/steam-user/-/steam-user-4.19.12.tgz",
+            "integrity": "sha512-7q9mDGc3YX5SI9QnXFqN52w+H8wCY1yB06sz2zweeLPWraq4VVYtymsjXybhu1mym7cKE23RFkFQSQclRK0fyw==",
             "requires": {
-                "@doctormckay/proxy-agent": "^1.0.0",
-                "@doctormckay/stats-reporter": "^1.0.3",
+                "@bbob/parser": "^2.2.0",
+                "@doctormckay/stdlib": "^1.11.1",
                 "@doctormckay/steam-crypto": "^1.2.0",
-                "adm-zip": "^0.4.7",
+                "adm-zip": "^0.4.13",
                 "appdirectory": "^0.1.0",
-                "async": "^2.5.0",
                 "binarykvparser": "^2.2.0",
-                "buffer-crc32": "^0.2.13",
                 "bytebuffer": "^5.0.0",
-                "file-manager": "^1.0.1",
+                "file-manager": "^2.0.0",
                 "lzma": "^2.3.2",
-                "protobufjs": "^5.0.2",
-                "steam-client": "^2.5.8",
-                "steam-totp": "^1.4.1",
+                "protobufjs": "^6.8.8",
+                "steam-appticket": "^1.0.1",
+                "steam-totp": "^2.0.1",
                 "steamid": "^1.1.0",
-                "vdf": "^0.0.2"
+                "vdf": "^0.0.2",
+                "websocket13": "^2.1.3"
             },
             "dependencies": {
-                "steam-totp": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/steam-totp/-/steam-totp-1.5.0.tgz",
-                    "integrity": "sha512-RMlBK5dFtgplDMYYGg/k80RqEntzBcl7C/0RF18fQh9+XPe/iEMsfKmIE+xj8I3hqJW1akANAC6gf+YpfZq52w==",
+                "file-manager": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/file-manager/-/file-manager-2.0.0.tgz",
+                    "integrity": "sha512-AX9jtqrrHK9JT4v3J7uMZGkDNiuuG4y4T6LoNm3lKzT/vReLCY8mnRWIpaG2ffNEpJHSkiwKejpu8x8THEYPzg=="
+                },
+                "long": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+                    "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+                },
+                "protobufjs": {
+                    "version": "6.11.2",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+                    "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
                     "requires": {
-                        "@doctormckay/stats-reporter": "^1.0.0"
+                        "@protobufjs/aspromise": "^1.1.2",
+                        "@protobufjs/base64": "^1.1.2",
+                        "@protobufjs/codegen": "^2.0.4",
+                        "@protobufjs/eventemitter": "^1.1.0",
+                        "@protobufjs/fetch": "^1.1.0",
+                        "@protobufjs/float": "^1.0.2",
+                        "@protobufjs/inquire": "^1.1.0",
+                        "@protobufjs/path": "^1.1.2",
+                        "@protobufjs/pool": "^1.1.0",
+                        "@protobufjs/utf8": "^1.1.0",
+                        "@types/long": "^4.0.1",
+                        "@types/node": ">=13.7.0",
+                        "long": "^4.0.0"
+                    }
+                },
+                "websocket13": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/websocket13/-/websocket13-2.2.0.tgz",
+                    "integrity": "sha512-m3aS0sLEM9dRM2+Cvgakdr/oLqyfAObdUlUqU3gdw3PuI81k1Hw3PWdwJsehvRRlScHolA13yYsx/X3OUzsTLA==",
+                    "requires": {
+                        "@doctormckay/stdlib": "^1.8.0",
+                        "bytebuffer": "^5.0.1",
+                        "permessage-deflate": "^0.1.6",
+                        "websocket-extensions": "^0.1.2"
                     }
                 }
             }
         },
         "steamcommunity": {
-            "version": "3.37.1",
-            "resolved": "https://registry.npmjs.org/steamcommunity/-/steamcommunity-3.37.1.tgz",
-            "integrity": "sha512-V1t0xiPkpu17FSn/Mh3O0ATKmslj6xLBBhqZYuMQVkx88CuZzCQxHadcOkE/Udx6+w/9HaWNRMXXmj7RcnaWnA==",
+            "version": "3.43.1",
+            "resolved": "https://registry.npmjs.org/steamcommunity/-/steamcommunity-3.43.1.tgz",
+            "integrity": "sha512-Nx+Iwas1EWpSIwEEfGw5jLm6Jrl0W/VL+0Ms9gRLnfqH8Ca1PEba7mDhar/Ny4RUdSmgrfy1ZBV99csjkZ5bog==",
             "requires": {
-                "@doctormckay/stats-reporter": "^1.0.2",
-                "async": "^2.1.4",
+                "async": "^2.6.3",
                 "cheerio": "0.22.0",
+                "image-size": "^0.8.2",
                 "node-bignumber": "^1.2.1",
-                "request": "^2.86.0",
-                "steam-totp": "^1.3.0",
-                "steamid": "^1.0.0",
-                "xml2js": "^0.4.11"
+                "request": "^2.88.0",
+                "steam-totp": "^1.5.0",
+                "steamid": "^1.1.3",
+                "xml2js": "^0.4.22"
             },
             "dependencies": {
                 "steam-totp": {
@@ -905,11 +2548,19 @@
             }
         },
         "steamid": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.0.tgz",
-            "integrity": "sha1-7M+/JFR/TpsdJ/y4PaYqakETmYY=",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/steamid/-/steamid-1.1.3.tgz",
+            "integrity": "sha512-t86YjtP1LtPt8D+TaIARm6PtC9tBnF1FhxQeLFs6ohG7vDUfQuy/M8II14rx1TTUkVuYoWHP/7DlvTtoCGULcw==",
             "requires": {
                 "cuint": "^0.2.1"
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "requires": {
+                "safe-buffer": "~5.1.0"
             }
         },
         "string-width": {
@@ -920,14 +2571,6 @@
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
-            }
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "requires": {
-                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {
@@ -1048,18 +2691,18 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+            "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "xmlbuilder": "~11.0.0"
             }
         },
         "xmlbuilder": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
         },
         "y18n": {
             "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "dependencies": {
         "merge": "^1.2.0",
         "steam-client": "^2.5.8",
-        "steam-totp": "^2.1.0",
-        "steam-tradeoffer-manager": "^2.9.3",
-        "steam-user": "^3.28.2",
-        "steamcommunity": "^3.35.1",
+        "steam-totp": "^2.1.1",
+        "steam-tradeoffer-manager": "^2.10.3",
+        "steam-user": "^4.19.12",
+        "steamcommunity": "^3.43.1",
         "tracer": "^0.9.1"
     },
     "engines": {


### PR DESCRIPTION
Steam format has changed
```
09-20 14:30:56.20 <info> Logging in as xxx
node:internal/fs/utils:879
  throw new ERR_INVALID_ARG_TYPE(
  ^

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (193)
    at Object.writeFile (node:fs:2106:5)
    at FileStorage.saveFile.FileStorage.writeFile (./steam-auto-confirmation/node_modules/file-manager/index.js:68:5)
    at SteamUser._handlers.<computed> (./steam-auto-confirmation/node_modules/steam-user/components/logon.js:294:18)
    at SteamUser._handleMessage (./steam-auto-confirmation/node_modules/steam-user/components/messages.js:249:30)
    at CMClient.emit (node:events:394:28)
    at CMClient._netMsgReceived (./steam-auto-confirmation/node_modules/steam-client/lib/cm_client.js:323:8)
    at CMClient.handlers.<computed> (./steam-auto-confirmation/node_modules/steam-client/lib/cm_client.js:609:8)
    at CMClient._netMsgReceived (./steam-auto-confirmation/node_modules/steam-client/lib/cm_client.js:305:24)
    at TCPConnection.emit (node:events:394:28)
    at TCPConnection._readPacket (./steam-auto-confirmation/node_modules/steam-client/lib/tcp_connection.js:183:7) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```
the change helps to cope with it. `npm outdated` was used to detect updates.